### PR TITLE
Fix removeFile filtering in upload modal

### DIFF
--- a/components/font/ModalUploadForm.tsx
+++ b/components/font/ModalUploadForm.tsx
@@ -80,7 +80,9 @@ export default function ModalUploadForm({ onUploadComplete }: ModalUploadFormPro
   };
 
   const removeFile = (fileId: string) => {
-    setFilesToUpload(prev => prev.filter(f => f.id !== fileId && f.status === 'pending'));
+    // Only remove the specific file. The previous logic kept only
+    // pending files, inadvertently dropping any others from the list.
+    setFilesToUpload(prev => prev.filter(f => f.id !== fileId));
   };
 
   const uploadSingleFileViaXHR = async (fileToProcess: UploadableFile) => {


### PR DESCRIPTION
## Summary
- prevent accidental deletion of non-pending files when removing an item in `ModalUploadForm`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_683f61996f08832b9172bb25f8b00731