### PR TITLE
Add multi-lane semantic font search

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -55,6 +55,106 @@
         { "fieldPath": "category", "order": "ASCENDING" },
         { "fieldPath": "text_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
       ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "density": "SPARSE_ALL",
+      "fields": [
+        { "fieldPath": "mood_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "mood_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "mood_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "density": "SPARSE_ALL",
+      "fields": [
+        { "fieldPath": "use_case_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "use_case_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "use_case_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "text_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "mood_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "use_case_vec", "vectorConfig": { "dimension": 2048, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "searchTokens", "arrayConfig": "CONTAINS" }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "searchTokens", "arrayConfig": "CONTAINS" }
+      ]
+    },
+    {
+      "collectionGroup": "fontfamilies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "searchTokens", "arrayConfig": "CONTAINS" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,8 @@
         "deploy": "firebase deploy --only functions",
         "logs": "firebase functions:log",
         "lint": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "backfill:search": "npm run build && node lib/scripts/backfillSearchVectors.js"
     },
     "engines": {
         "node": "22"

--- a/functions/src/ai/enrich/parse.ts
+++ b/functions/src/ai/enrich/parse.ts
@@ -5,6 +5,7 @@ import { getConfigValue } from "../../config/remoteConfig";
 import type { FontEnrichment, FontFamilyDoc } from "../../models/catalog.models";
 import type { GfCategory } from "../../storage/canonicalize";
 import { PROMPT_VERSION } from "./schema";
+import { isSearchIndexedAtVersion } from "../../search/searchDocument";
 
 /** Parse the model's JSON text into a FontEnrichment. Shared by realtime + batch. */
 export function parseAnalysis(family: FontFamilyDoc, text: string | undefined | null): FontEnrichment | null {
@@ -48,6 +49,7 @@ export function isEnrichedAtCurrentVersion(family: FontFamilyDoc): boolean {
     family.status === "enriched" &&
     prior?.promptVersion === v.promptVersion &&
     prior?.modelId === v.analysisModel &&
-    prior?.embeddingVersion === v.embedVersion
+    prior?.embeddingVersion === v.embedVersion &&
+    isSearchIndexedAtVersion(family, { embeddingVersion: v.embedVersion, promptVersion: v.promptVersion })
   );
 }

--- a/functions/src/ai/enrich/schema.ts
+++ b/functions/src/ai/enrich/schema.ts
@@ -1,4 +1,5 @@
 import type { FontEnrichment, FontFamilyDoc } from "../../models/catalog.models";
+import { buildLaneEmbeddingText } from "../../search/searchDocument";
 
 export const PROMPT_VERSION = "enrich-v1";
 
@@ -40,16 +41,13 @@ export function buildPrompt(family: FontFamilyDoc, hasImage: boolean, withKey = 
 }
 
 export function buildEmbeddingText(family: FontFamilyDoc, e: FontEnrichment): string {
-  return [
-    family.name,
-    e.classification || family.classification,
-    e.summary,
-    e.voice,
-    (e.moods || []).join(", "),
-    (e.useCases || []).join(", "),
-    (e.pairingHints || []).join(", "),
-    family.foundry,
-  ]
-    .filter(Boolean)
-    .join(". ");
+  return buildLaneEmbeddingText({ ...family, enrichment: e }, "text");
+}
+
+export function buildMoodEmbeddingText(family: FontFamilyDoc, e: FontEnrichment): string {
+  return buildLaneEmbeddingText({ ...family, enrichment: e }, "mood");
+}
+
+export function buildUseCaseEmbeddingText(family: FontFamilyDoc, e: FontEnrichment): string {
+  return buildLaneEmbeddingText({ ...family, enrichment: e }, "useCase");
 }

--- a/functions/src/ai/enrich/update.ts
+++ b/functions/src/ai/enrich/update.ts
@@ -5,7 +5,8 @@ import { renderSpecimen } from "../../render/specimen";
 import { embedText, embeddingModelId, embeddingDims } from "../embeddings";
 import { publicBucketName } from "../../config/catalogConfig";
 import type { FontEnrichment, FontFamilyDoc } from "../../models/catalog.models";
-import { buildEmbeddingText } from "./schema";
+import { PROMPT_VERSION, buildEmbeddingText, buildMoodEmbeddingText, buildUseCaseEmbeddingText } from "./schema";
+import { buildSearchDocument } from "../../search/searchDocument";
 
 /** Download the cover face and render its specimen PNG (null on any failure). */
 export async function renderFamilySpecimen(family: FontFamilyDoc): Promise<Buffer | null> {
@@ -25,17 +26,38 @@ export async function buildEnrichmentUpdate(
   family: FontFamilyDoc,
   enrichment: FontEnrichment
 ): Promise<Record<string, unknown>> {
-  const vec = await embedText(buildEmbeddingText(family, enrichment), "RETRIEVAL_DOCUMENT");
+  const [textVec, moodVec, useCaseVec] = await Promise.all([
+    embedText(buildEmbeddingText(family, enrichment), "RETRIEVAL_DOCUMENT"),
+    embedText(buildMoodEmbeddingText(family, enrichment), "RETRIEVAL_DOCUMENT"),
+    embedText(buildUseCaseEmbeddingText(family, enrichment), "RETRIEVAL_DOCUMENT"),
+  ]);
+  const hasAnyVector = Boolean(textVec || moodVec || useCaseVec);
+  const embeddingModel = hasAnyVector ? embeddingModelId() : undefined;
+  const embeddingVersion = hasAnyVector ? `${embeddingModelId()}:${embeddingDims()}` : undefined;
+  const searchDoc = embeddingVersion
+    ? buildSearchDocument({ ...family, enrichment }, { embeddingModel, embeddingVersion, promptVersion: enrichment.promptVersion ?? PROMPT_VERSION })
+    : {};
   const update: Record<string, unknown> = {
     enrichment: {
       ...enrichment,
-      embeddingModel: vec ? embeddingModelId() : undefined,
-      embeddingVersion: vec ? `${embeddingModelId()}:${embeddingDims()}` : undefined,
+      embeddingModel,
+      embeddingVersion,
       enrichedAt: FieldValue.serverTimestamp(),
     },
+    ...searchDoc,
+    ...(searchDoc.searchMeta
+      ? {
+          searchMeta: {
+            ...searchDoc.searchMeta,
+            generatedAt: FieldValue.serverTimestamp(),
+          },
+        }
+      : {}),
     status: "enriched",
     updatedAt: FieldValue.serverTimestamp(),
   };
-  if (vec) update.text_vec = FieldValue.vector(vec);
+  if (textVec) update.text_vec = FieldValue.vector(textVec);
+  if (moodVec) update.mood_vec = FieldValue.vector(moodVec);
+  if (useCaseVec) update.use_case_vec = FieldValue.vector(useCaseVec);
   return update;
 }

--- a/functions/src/ai/enrichFont.ts
+++ b/functions/src/ai/enrichFont.ts
@@ -13,6 +13,8 @@ export {
   ANALYSIS_SCHEMA,
   buildPrompt,
   buildEmbeddingText,
+  buildMoodEmbeddingText,
+  buildUseCaseEmbeddingText,
 } from "./enrich/schema";
 export { parseAnalysis, currentEnrichmentVersions, isEnrichedAtCurrentVersion } from "./enrich/parse";
 export { renderFamilySpecimen, buildEnrichmentUpdate } from "./enrich/update";

--- a/functions/src/models/catalog.models.ts
+++ b/functions/src/models/catalog.models.ts
@@ -76,6 +76,13 @@ export interface FontEnrichment {
   enrichedAt?: FirebaseFirestore.Timestamp | Date | string;
 }
 
+export interface SearchMeta {
+  embeddingModel: string;
+  embeddingVersion: string;
+  promptVersion: string;
+  generatedAt?: FirebaseFirestore.Timestamp | Date | string;
+}
+
 /** The family document. Vector fields are written via FieldValue.vector(). */
 export interface FontFamilyDoc {
   id: string; // family slug
@@ -95,9 +102,14 @@ export interface FontFamilyDoc {
   ownerId?: string;
   status: FamilyStatus;
   version: number; // bumped on each (re)write of served assets — used in CDN paths
+  searchText?: string;
+  searchTokens?: string[];
+  searchMeta?: SearchMeta;
   // Vector fields (Firestore VectorValue) — present only after enrichment.
   // Typed loosely because admin SDK writes them via FieldValue.vector(number[]).
   text_vec?: unknown;
+  mood_vec?: unknown;
+  use_case_vec?: unknown;
   image_vec?: unknown;
   createdAt?: FirebaseFirestore.Timestamp | Date | string;
   updatedAt?: FirebaseFirestore.Timestamp | Date | string;

--- a/functions/src/scripts/backfillSearchVectors.ts
+++ b/functions/src/scripts/backfillSearchVectors.ts
@@ -1,0 +1,143 @@
+import { getFirestore, FieldValue, type Query } from "firebase-admin/firestore";
+import { initializeApp, getApps } from "firebase-admin/app";
+import { embedText, embeddingDims, embeddingModelId } from "../ai/embeddings";
+import { PROMPT_VERSION } from "../ai/enrich/schema";
+import type { FontFamilyDoc } from "../models/catalog.models";
+import { FAMILIES_COLLECTION } from "../storage/familyStore";
+import {
+  buildLaneEmbeddingText,
+  buildSearchDocument,
+  isSearchIndexedAtVersion,
+  type SearchVectorLane,
+} from "../search/searchDocument";
+
+export interface BackfillArgs {
+  ownerId?: string;
+  limit?: number;
+  force: boolean;
+  dryRun: boolean;
+}
+
+export interface SearchVersionForBackfill {
+  embeddingVersion: string;
+  promptVersion: string;
+}
+
+const VECTOR_FIELDS: Record<SearchVectorLane, "text_vec" | "mood_vec" | "use_case_vec"> = {
+  text: "text_vec",
+  mood: "mood_vec",
+  useCase: "use_case_vec",
+};
+
+export function parseBackfillArgs(argv: string[]): BackfillArgs {
+  const parsed: BackfillArgs = { force: false, dryRun: false };
+  for (const arg of argv) {
+    if (arg === "--force") parsed.force = true;
+    else if (arg === "--dryRun") parsed.dryRun = true;
+    else if (arg.startsWith("--ownerId=")) parsed.ownerId = arg.slice("--ownerId=".length);
+    else if (arg.startsWith("--limit=")) {
+      const limit = Number(arg.slice("--limit=".length));
+      if (Number.isInteger(limit) && limit > 0) parsed.limit = limit;
+    }
+  }
+  return parsed;
+}
+
+export function currentSearchBackfillVersion(): SearchVersionForBackfill & { embeddingModel: string } {
+  const embeddingModel = embeddingModelId();
+  return {
+    embeddingModel,
+    embeddingVersion: `${embeddingModel}:${embeddingDims()}`,
+    promptVersion: PROMPT_VERSION,
+  };
+}
+
+export function shouldBackfillFamily(
+  family: FontFamilyDoc,
+  version: SearchVersionForBackfill,
+  force: boolean
+): boolean {
+  if (force) return true;
+  return !isSearchIndexedAtVersion(family, version);
+}
+
+async function buildBackfillUpdate(family: FontFamilyDoc): Promise<Record<string, unknown>> {
+  const version = currentSearchBackfillVersion();
+  const familyForSearch: FontFamilyDoc = {
+    ...family,
+    enrichment: family.enrichment
+      ? {
+          ...family.enrichment,
+          embeddingModel: version.embeddingModel,
+          embeddingVersion: version.embeddingVersion,
+          promptVersion: family.enrichment.promptVersion ?? version.promptVersion,
+        }
+      : family.enrichment,
+  };
+
+  const searchDoc = buildSearchDocument(familyForSearch, version);
+  const update: Record<string, unknown> = {
+    ...searchDoc,
+    searchMeta: {
+      ...searchDoc.searchMeta,
+      generatedAt: FieldValue.serverTimestamp(),
+    },
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+
+  await Promise.all(
+    (Object.keys(VECTOR_FIELDS) as SearchVectorLane[]).map(async (lane) => {
+      const vector = await embedText(buildLaneEmbeddingText(familyForSearch, lane), "RETRIEVAL_DOCUMENT");
+      if (vector) update[VECTOR_FIELDS[lane]] = FieldValue.vector(vector);
+    })
+  );
+
+  return update;
+}
+
+async function run(): Promise<void> {
+  if (!getApps().length) initializeApp();
+  const args = parseBackfillArgs(process.argv.slice(2));
+  const version = currentSearchBackfillVersion();
+  const db = getFirestore();
+
+  let query: Query = db.collection(FAMILIES_COLLECTION);
+  if (args.ownerId) query = query.where("ownerId", "==", args.ownerId);
+  if (args.limit) query = query.limit(args.limit);
+
+  const snap = await query.get();
+  let skipped = 0;
+  let updated = 0;
+  let failed = 0;
+
+  for (const doc of snap.docs) {
+    const family = doc.data() as FontFamilyDoc;
+    if (!shouldBackfillFamily(family, version, args.force)) {
+      skipped += 1;
+      continue;
+    }
+
+    try {
+      if (!args.dryRun) {
+        const update = await buildBackfillUpdate(family);
+        await doc.ref.set(update, { merge: true });
+      }
+      updated += 1;
+      console.log(`${args.dryRun ? "would update" : "updated"} ${doc.id}`);
+    } catch (error) {
+      failed += 1;
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`failed ${doc.id}: ${message}`);
+    }
+  }
+
+  console.log(JSON.stringify({ scanned: snap.size, skipped, updated, failed, dryRun: args.dryRun }, null, 2));
+  if (failed > 0) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/functions/src/search/queryEmbeddingCache.ts
+++ b/functions/src/search/queryEmbeddingCache.ts
@@ -1,0 +1,81 @@
+import { createHash } from "crypto";
+import { FieldValue, Timestamp, type Firestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions";
+import { embedText, embeddingDims, embeddingModelId } from "../ai/embeddings";
+import { normalizeSearchText, type SearchVectorLane } from "./searchDocument";
+
+const CACHE_COLLECTION = "searchQueryCache";
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface QueryEmbeddingCacheInput {
+  db: Firestore;
+  query: string;
+  lane: SearchVectorLane;
+}
+
+export function queryEmbeddingVersion(): { embeddingModel: string; embeddingVersion: string } {
+  const embeddingModel = embeddingModelId();
+  return { embeddingModel, embeddingVersion: `${embeddingModel}:${embeddingDims()}` };
+}
+
+export function queryCacheKey(input: { query: string; lane: SearchVectorLane; embeddingVersion: string }): string {
+  const normalizedQuery = normalizeSearchText(input.query);
+  return createHash("sha256")
+    .update(JSON.stringify({ q: normalizedQuery, lane: input.lane, embeddingVersion: input.embeddingVersion }))
+    .digest("hex");
+}
+
+function isFreshCacheDoc(data: FirebaseFirestore.DocumentData | undefined, now: number): data is { vector: number[] } {
+  const expiresAt = data?.expiresAt;
+  const expiresAtMs =
+    expiresAt instanceof Timestamp
+      ? expiresAt.toMillis()
+      : typeof expiresAt?.toMillis === "function"
+        ? expiresAt.toMillis()
+        : 0;
+  return Array.isArray(data?.vector) && data.vector.length > 0 && expiresAtMs > now;
+}
+
+export async function getOrCreateQueryEmbedding(input: QueryEmbeddingCacheInput): Promise<number[] | null> {
+  const started = Date.now();
+  const { embeddingModel, embeddingVersion } = queryEmbeddingVersion();
+  const key = queryCacheKey({ query: input.query, lane: input.lane, embeddingVersion });
+  const ref = input.db.collection(CACHE_COLLECTION).doc(key);
+  const now = Date.now();
+
+  try {
+    const snap = await ref.get();
+    const lookupMs = Date.now() - started;
+    if (snap.exists && isFreshCacheDoc(snap.data(), now)) {
+      logger.info("search embedding cache hit", { lane: input.lane, lookupMs });
+      return snap.data()?.vector as number[];
+    }
+    logger.info("search embedding cache miss", { lane: input.lane, lookupMs });
+  } catch (e: any) {
+    logger.warn("search embedding cache lookup failed", { lane: input.lane, message: e?.message });
+  }
+
+  const embeddingStarted = Date.now();
+  const vector = await embedText(input.query, "RETRIEVAL_QUERY");
+  logger.info("search embedding generated", { lane: input.lane, embeddingMs: Date.now() - embeddingStarted });
+  if (!vector) return null;
+
+  try {
+    await ref.set(
+      {
+        key,
+        lane: input.lane,
+        normalizedQuery: normalizeSearchText(input.query),
+        embeddingModel,
+        embeddingVersion,
+        vector,
+        createdAt: FieldValue.serverTimestamp(),
+        expiresAt: Timestamp.fromMillis(now + TTL_MS),
+      },
+      { merge: true }
+    );
+  } catch (e: any) {
+    logger.warn("search embedding cache write failed", { lane: input.lane, message: e?.message });
+  }
+  return vector;
+}

--- a/functions/src/search/scoring.ts
+++ b/functions/src/search/scoring.ts
@@ -1,0 +1,123 @@
+import type { FontFamilyDoc } from "../models/catalog.models";
+import { normalizeSearchText, tokenizeSearchText, type SearchVectorLane } from "./searchDocument";
+
+export interface SearchWeights {
+  textSemantic: number;
+  moodSemantic: number;
+  useCaseSemantic: number;
+  exact: number;
+  quality: number;
+}
+
+export interface SearchScoreBreakdown {
+  textSemantic: number;
+  moodSemantic: number;
+  useCaseSemantic: number;
+  exact: number;
+  quality: number;
+}
+
+export interface SearchCandidate {
+  family: FontFamilyDoc;
+  scores: SearchScoreBreakdown;
+}
+
+export const DEFAULT_SEARCH_WEIGHTS: SearchWeights = {
+  textSemantic: 0.45,
+  moodSemantic: 0.2,
+  useCaseSemantic: 0.2,
+  exact: 0.1,
+  quality: 0.05,
+};
+
+const EMPTY_SCORES: SearchScoreBreakdown = {
+  textSemantic: 0,
+  moodSemantic: 0,
+  useCaseSemantic: 0,
+  exact: 0,
+  quality: 0,
+};
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+export function semanticScoreFromDistance(distance: unknown): number {
+  return typeof distance === "number" ? clamp01(1 - distance) : 0;
+}
+
+function nameScore(query: string, family: FontFamilyDoc): number {
+  const normalizedName = normalizeSearchText(family.name);
+  if (!query || !normalizedName) return 0;
+  if (query === normalizedName) return 1;
+  if (normalizedName.startsWith(query)) return 0.88;
+  if (normalizedName.includes(query)) return 0.78;
+  return 0;
+}
+
+export function exactMatchScore(rawQuery: string, family: FontFamilyDoc): number {
+  const query = normalizeSearchText(rawQuery);
+  const queryTokens = tokenizeSearchText([query]);
+  if (!queryTokens.length) return 0;
+
+  const tokenSet = new Set(family.searchTokens ?? tokenizeSearchText([
+    family.name,
+    family.slug,
+    family.fileBase,
+    family.category,
+    family.classification,
+    family.enrichment?.classification,
+    ...(family.enrichment?.moods ?? []),
+    ...(family.enrichment?.useCases ?? []),
+  ]));
+
+  const matches = queryTokens.filter((token) => tokenSet.has(token)).length;
+  const tokenScore = matches / queryTokens.length;
+  const categoryScore = normalizeSearchText(family.category).includes(query) ? 0.8 : 0;
+  const classification = normalizeSearchText(family.enrichment?.classification ?? family.classification ?? "");
+  const classificationScore = classification.includes(query) ? 0.7 : 0;
+  return clamp01(Math.max(nameScore(query, family), tokenScore, categoryScore, classificationScore));
+}
+
+export function qualityScore(family: FontFamilyDoc): number {
+  const confidence = family.enrichment?.confidence;
+  if (typeof confidence === "number") return clamp01(confidence);
+  if (family.status === "enriched") return 0.75;
+  if (family.status === "ready") return 0.5;
+  return 0.25;
+}
+
+function laneScoreKey(lane: SearchVectorLane): keyof SearchScoreBreakdown {
+  if (lane === "mood") return "moodSemantic";
+  if (lane === "useCase") return "useCaseSemantic";
+  return "textSemantic";
+}
+
+export function mergeSearchCandidate(
+  candidates: Map<string, SearchCandidate>,
+  family: FontFamilyDoc,
+  evidence: { lane?: SearchVectorLane; score?: number; exact?: number; quality?: number }
+): SearchCandidate {
+  const id = family.id || family.slug;
+  const existing = candidates.get(id) ?? { family, scores: { ...EMPTY_SCORES } };
+  existing.family = { ...existing.family, ...family };
+  if (evidence.lane) {
+    const key = laneScoreKey(evidence.lane);
+    existing.scores[key] = Math.max(existing.scores[key], clamp01(evidence.score ?? 0));
+  }
+  if (evidence.exact !== undefined) existing.scores.exact = Math.max(existing.scores.exact, clamp01(evidence.exact));
+  if (evidence.quality !== undefined) existing.scores.quality = Math.max(existing.scores.quality, clamp01(evidence.quality));
+  candidates.set(id, existing);
+  return existing;
+}
+
+export function fuseCandidateScore(scores: SearchScoreBreakdown, weights: SearchWeights = DEFAULT_SEARCH_WEIGHTS): number {
+  return (
+    scores.textSemantic * weights.textSemantic +
+    scores.moodSemantic * weights.moodSemantic +
+    scores.useCaseSemantic * weights.useCaseSemantic +
+    scores.exact * weights.exact +
+    scores.quality * weights.quality
+  );
+}

--- a/functions/src/search/searchDocument.ts
+++ b/functions/src/search/searchDocument.ts
@@ -1,0 +1,162 @@
+import type { FontEnrichment, FontFamilyDoc, SearchMeta } from "../models/catalog.models";
+
+export type SearchVectorLane = "text" | "mood" | "useCase";
+
+export const SEARCH_VECTOR_LANES: SearchVectorLane[] = ["text", "mood", "useCase"];
+
+export interface SearchVersionInfo {
+  embeddingModel?: string;
+  embeddingVersion: string;
+  promptVersion: string;
+}
+
+const MAX_TOKEN_COUNT = 80;
+
+function cleanPart(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : undefined;
+}
+
+function cleanParts(values: unknown[]): string[] {
+  return values.flatMap((value) => {
+    if (Array.isArray(value)) return cleanParts(value);
+    const cleaned = cleanPart(value);
+    return cleaned ? [cleaned] : [];
+  });
+}
+
+function enrichmentFor(family: FontFamilyDoc): FontEnrichment | undefined {
+  return family.enrichment;
+}
+
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function tokenizeSearchText(parts: Array<string | undefined | null>): string[] {
+  const tokens = new Set<string>();
+  for (const part of parts) {
+    if (!part) continue;
+    const normalized = normalizeSearchText(part.replace(/_/g, " "));
+    for (const token of normalized.split(" ")) {
+      if (token.length >= 2) tokens.add(token);
+    }
+  }
+  return [...tokens].slice(0, MAX_TOKEN_COUNT);
+}
+
+export function buildLaneEmbeddingText(family: FontFamilyDoc, lane: SearchVectorLane): string {
+  const e = enrichmentFor(family);
+  const classification = e?.classification ?? family.classification;
+  const category = e?.category ?? family.category;
+  const shared = cleanParts([family.name, family.fileBase, category, classification, family.foundry, family.designer]);
+
+  if (lane === "mood") {
+    return cleanParts([
+      ...shared,
+      e?.voice,
+      e?.moods,
+      e?.summary,
+    ]).join(". ");
+  }
+
+  if (lane === "useCase") {
+    return cleanParts([
+      family.name,
+      category,
+      classification,
+      e?.useCases,
+      e?.pairingHints,
+      e?.summary,
+    ]).join(". ");
+  }
+
+  return cleanParts([
+    ...shared,
+    e?.summary,
+    e?.voice,
+    e?.moods,
+    e?.useCases,
+    e?.pairingHints,
+    family.license,
+    family.subsets,
+    (family.axes ?? []).map((axis) => [axis.tag, axis.name].filter(Boolean).join(" ")),
+    (family.faces ?? []).map((face) => [face.styleName, face.weightName, face.fullName, face.postScriptName].filter(Boolean).join(" ")),
+  ]).join(". ");
+}
+
+export function buildQueryLaneInput(query: string, lane: SearchVectorLane): string {
+  const normalized = normalizeSearchText(query);
+  if (!normalized) return "";
+  if (lane === "mood") return normalized;
+  if (lane === "useCase") return normalized;
+  return normalized;
+}
+
+export function buildSearchText(family: FontFamilyDoc): string {
+  return buildLaneEmbeddingText(family, "text");
+}
+
+export function buildSearchTokens(family: FontFamilyDoc): string[] {
+  const e = enrichmentFor(family);
+  return tokenizeSearchText([
+    family.id,
+    family.slug,
+    family.name,
+    family.fileBase,
+    family.category,
+    family.classification,
+    family.foundry,
+    family.designer,
+    e?.category,
+    e?.classification,
+    e?.summary,
+    e?.voice,
+    ...(e?.moods ?? []),
+    ...(e?.useCases ?? []),
+    ...(e?.pairingHints ?? []),
+    ...(family.subsets ?? []),
+    ...(family.axes ?? []).flatMap((axis) => [axis.tag, axis.name]),
+    ...(family.faces ?? []).flatMap((face) => [face.styleName, face.weightName, face.fullName, face.postScriptName]),
+  ]);
+}
+
+export function buildSearchMeta(version: SearchVersionInfo): SearchMeta {
+  return {
+    embeddingModel: version.embeddingModel ?? version.embeddingVersion.split(":")[0],
+    embeddingVersion: version.embeddingVersion,
+    promptVersion: version.promptVersion,
+  };
+}
+
+export function buildSearchDocument(
+  family: FontFamilyDoc,
+  version: SearchVersionInfo
+): Pick<FontFamilyDoc, "searchText" | "searchTokens" | "searchMeta"> {
+  return {
+    searchText: buildSearchText(family),
+    searchTokens: buildSearchTokens(family),
+    searchMeta: buildSearchMeta(version),
+  };
+}
+
+export function isSearchIndexedAtVersion(family: FontFamilyDoc, version: Omit<SearchVersionInfo, "embeddingModel">): boolean {
+  return (
+    Boolean(family.searchText) &&
+    Boolean(family.searchTokens?.length) &&
+    family.searchMeta?.embeddingVersion === version.embeddingVersion &&
+    family.searchMeta?.promptVersion === version.promptVersion &&
+    family.text_vec !== undefined &&
+    family.mood_vec !== undefined &&
+    family.use_case_vec !== undefined
+  );
+}

--- a/functions/src/search/searchFonts.ts
+++ b/functions/src/search/searchFonts.ts
@@ -1,23 +1,41 @@
 /**
- * Semantic font search over the rebuilt catalog using Firestore-native vector
- * search (findNearest / KNN). Structured filters pre-narrow the collection
- * (also keeping brute-force KNN fast); the query text is embedded and matched
- * against each family's `text_vec`. Falls back to a filtered listing when there
- * is no query or no embedding/vectors yet.
+ * Hybrid semantic font search over the rebuilt catalog.
+ *
+ * Three Firestore vector lanes capture broad intent, mood/voice, and use case.
+ * An exact/token lane catches family names, categories, classifications, moods,
+ * and jobs-to-be-done terms. Candidates are merged by family id and reranked
+ * with deterministic score fusion.
  */
 import { getFirestore } from 'firebase-admin/firestore';
 import type { Query, QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions';
-import { embedText } from '../ai/embeddings';
 import { getConfigNumber } from '../config/remoteConfig';
 import { RC_KEYS, RC_DEFAULTS } from '../config/rcKeys';
 import { FAMILIES_COLLECTION } from '../storage/familyStore';
 import type { FontFamilyDoc } from '../models/catalog.models';
+import { getOrCreateQueryEmbedding } from './queryEmbeddingCache';
+import {
+  SEARCH_VECTOR_LANES,
+  buildQueryLaneInput,
+  normalizeSearchText,
+  tokenizeSearchText,
+  type SearchVectorLane,
+} from './searchDocument';
+import {
+  DEFAULT_SEARCH_WEIGHTS,
+  exactMatchScore,
+  fuseCandidateScore,
+  mergeSearchCandidate,
+  qualityScore,
+  semanticScoreFromDistance,
+  type SearchScoreBreakdown,
+} from './scoring';
 
 export interface SearchRequest {
   q?: string;
   filters?: { category?: string; ownerId?: string; isVariable?: boolean };
   limit?: number;
+  debug?: boolean;
 }
 
 export interface SearchResultItem {
@@ -31,9 +49,16 @@ export interface SearchResultItem {
   coverUrl?: string;
   styleCount: number;
   score?: number;
+  scoreBreakdown?: SearchScoreBreakdown;
 }
 
-function toItem(family: FontFamilyDoc, distance?: number): SearchResultItem {
+const VECTOR_FIELD_BY_LANE: Record<SearchVectorLane, 'text_vec' | 'mood_vec' | 'use_case_vec'> = {
+  text: 'text_vec',
+  mood: 'mood_vec',
+  useCase: 'use_case_vec',
+};
+
+function toItem(family: FontFamilyDoc, score?: number, scoreBreakdown?: SearchScoreBreakdown): SearchResultItem {
   const cover = family.faces?.find((f) => f.id === family.coverFaceId) || family.faces?.[0];
   return {
     id: family.id,
@@ -45,49 +70,153 @@ function toItem(family: FontFamilyDoc, distance?: number): SearchResultItem {
     moods: family.enrichment?.moods,
     coverUrl: cover?.woff2?.url,
     styleCount: family.faces?.length ?? 0,
-    score: typeof distance === 'number' ? Math.max(0, 1 - distance) : undefined,
+    score,
+    ...(scoreBreakdown ? { scoreBreakdown } : {}),
   };
 }
 
-export async function searchFonts(req: SearchRequest): Promise<{ results: SearchResultItem[] }> {
-  const db = getFirestore();
-  const topK = req.limit ?? getConfigNumber(RC_KEYS.searchTopK, Number(RC_DEFAULTS[RC_KEYS.searchTopK]));
+function isVariableFamily(family: FontFamilyDoc): boolean {
+  return family.faces?.some((face) => face.isVariable) ?? false;
+}
 
-  let base: Query = db.collection(FAMILIES_COLLECTION);
+function isSearchableStatus(family: FontFamilyDoc): boolean {
+  return family.status === 'ready' || family.status === 'enriched';
+}
+
+function applyStructuredFilters(query: Query, req: SearchRequest): Query {
+  let base = query;
   if (req.filters?.ownerId) base = base.where('ownerId', '==', req.filters.ownerId);
   if (req.filters?.category) base = base.where('category', '==', req.filters.category);
+  return base;
+}
 
+async function runVectorLane(
+  base: Query,
+  lane: SearchVectorLane,
+  vector: number[],
+  topK: number
+): Promise<QueryDocumentSnapshot[]> {
+  const started = Date.now();
+  try {
+    const snap = await base
+      .findNearest({
+        vectorField: VECTOR_FIELD_BY_LANE[lane],
+        queryVector: vector,
+        limit: topK,
+        distanceMeasure: 'COSINE',
+        distanceResultField: '_distance',
+      })
+      .get();
+    logger.info('search vector lane complete', { lane, count: snap.docs.length, ms: Date.now() - started });
+    return snap.docs;
+  } catch (e: any) {
+    logger.warn('search vector lane failed', { lane, message: e?.message, ms: Date.now() - started });
+    return [];
+  }
+}
+
+async function runExactLane(base: Query, q: string, topK: number): Promise<QueryDocumentSnapshot[]> {
+  const started = Date.now();
+  const tokens = tokenizeSearchText([q]).slice(0, 30);
+  if (tokens.length === 0) return [];
+  try {
+    const snap = await base.where('searchTokens', 'array-contains-any', tokens).limit(topK).get();
+    logger.info('search exact lane complete', { count: snap.docs.length, ms: Date.now() - started });
+    return snap.docs;
+  } catch (e: any) {
+    logger.warn('search exact lane failed', { message: e?.message, ms: Date.now() - started });
+    return [];
+  }
+}
+
+export async function searchFonts(req: SearchRequest): Promise<{ results: SearchResultItem[] }> {
+  const totalStarted = Date.now();
+  const db = getFirestore();
+  const topK = req.limit ?? getConfigNumber(RC_KEYS.searchTopK, Number(RC_DEFAULTS[RC_KEYS.searchTopK]));
   const q = (req.q || '').trim();
-  let docs: QueryDocumentSnapshot[] = [];
+  const normalizedQuery = normalizeSearchText(q);
 
-  if (q) {
-    const vec = await embedText(q, 'RETRIEVAL_QUERY');
-    if (vec) {
-      try {
-        const vq = base.findNearest({
-          vectorField: 'text_vec',
-          queryVector: vec,
-          limit: topK,
-          distanceMeasure: 'COSINE',
-          distanceResultField: '_distance',
-        });
-        docs = (await vq.get()).docs;
-      } catch (e: any) {
-        logger.warn('vector search failed; falling back to listing', { message: e?.message });
-      }
+  const base = applyStructuredFilters(db.collection(FAMILIES_COLLECTION), req);
+
+  if (!normalizedQuery) {
+    let listing = (await base.limit(topK).get()).docs.map((doc) => doc.data() as FontFamilyDoc);
+    listing = listing.filter(isSearchableStatus);
+    if (req.filters?.isVariable !== undefined) {
+      listing = listing.filter((family) => isVariableFamily(family) === req.filters?.isVariable);
+    }
+    logger.info('search fallback listing complete', { count: listing.length, totalMs: Date.now() - totalStarted });
+    return { results: listing.map((family) => toItem(family)) };
+  }
+
+  const exactPromise = runExactLane(base, normalizedQuery, topK);
+  const embeddingStarted = Date.now();
+  const laneVectors = await Promise.all(
+    SEARCH_VECTOR_LANES.map(async (lane) => ({
+      lane,
+      vector: await getOrCreateQueryEmbedding({
+        db,
+        lane,
+        query: buildQueryLaneInput(normalizedQuery, lane),
+      }),
+    }))
+  );
+  logger.info('search query embeddings complete', { ms: Date.now() - embeddingStarted });
+
+  const vectorDocsByLane = await Promise.all(
+    laneVectors.map(({ lane, vector }) => (vector ? runVectorLane(base, lane, vector, topK) : Promise.resolve([])))
+  );
+  const exactDocs = await exactPromise;
+
+  const mergeStarted = Date.now();
+  const candidates = new Map<string, ReturnType<typeof mergeSearchCandidate>>();
+  for (const [index, docs] of vectorDocsByLane.entries()) {
+    const lane = SEARCH_VECTOR_LANES[index];
+    for (const doc of docs) {
+      mergeSearchCandidate(candidates, doc.data() as FontFamilyDoc, {
+        lane,
+        score: semanticScoreFromDistance(doc.get('_distance')),
+      });
     }
   }
 
-  if (docs.length === 0) {
-    docs = (await base.limit(topK).get()).docs;
-  }
-
-  let results = docs.map((d) => toItem(d.data() as FontFamilyDoc, d.get('_distance')));
-  if (req.filters?.isVariable !== undefined) {
-    results = results.filter((r) => {
-      const fam = docs.find((d) => d.id === r.id)?.data() as FontFamilyDoc | undefined;
-      return fam?.faces?.some((f) => f.isVariable) === req.filters!.isVariable;
+  for (const doc of exactDocs) {
+    const family = doc.data() as FontFamilyDoc;
+    mergeSearchCandidate(candidates, family, {
+      exact: exactMatchScore(normalizedQuery, family),
     });
   }
+
+  if (candidates.size === 0) {
+    const docs = (await base.limit(topK).get()).docs;
+    for (const doc of docs) {
+      const family = doc.data() as FontFamilyDoc;
+      mergeSearchCandidate(candidates, family, {
+        exact: exactMatchScore(normalizedQuery, family),
+      });
+    }
+  }
+
+  const results = [...candidates.values()]
+    .map((candidate) => {
+      const scores = {
+        ...candidate.scores,
+        exact: Math.max(candidate.scores.exact, exactMatchScore(normalizedQuery, candidate.family)),
+        quality: qualityScore(candidate.family),
+      };
+      const score = fuseCandidateScore(scores, DEFAULT_SEARCH_WEIGHTS);
+      return { family: candidate.family, score, scores };
+    })
+    .filter(({ family }) => isSearchableStatus(family))
+    .filter(({ family }) => req.filters?.isVariable === undefined || isVariableFamily(family) === req.filters?.isVariable)
+    .sort((a, b) => b.score - a.score || a.family.name.localeCompare(b.family.name))
+    .slice(0, topK)
+    .map(({ family, score, scores }) => toItem(family, score, req.debug ? scores : undefined));
+
+  logger.info('search merge/rerank complete', {
+    candidates: candidates.size,
+    results: results.length,
+    ms: Date.now() - mergeStarted,
+    totalMs: Date.now() - totalStarted,
+  });
   return { results };
 }

--- a/functions/tests/search/backfillSearchVectors.test.ts
+++ b/functions/tests/search/backfillSearchVectors.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { FontFamilyDoc } from "../../src/models/catalog.models";
+import { parseBackfillArgs, shouldBackfillFamily } from "../../src/scripts/backfillSearchVectors";
+
+function family(overrides: Partial<FontFamilyDoc> = {}): FontFamilyDoc {
+  return {
+    id: "editorial-sans",
+    slug: "editorial-sans",
+    name: "Editorial Sans",
+    fileBase: "EditorialSans",
+    category: "SANS_SERIF",
+    faces: [],
+    status: "enriched",
+    version: 1,
+    searchText: "Editorial Sans",
+    searchTokens: ["editorial", "sans"],
+    searchMeta: {
+      embeddingModel: "gemini-embedding-2-preview",
+      embeddingVersion: "gemini-embedding-2-preview:768",
+      promptVersion: "enrich-v1",
+    },
+    text_vec: {},
+    mood_vec: {},
+    use_case_vec: {},
+    ...overrides,
+  };
+}
+
+describe("search vector backfill helpers", () => {
+  it("skips docs already indexed at the current search version", () => {
+    expect(
+      shouldBackfillFamily(
+        family(),
+        {
+          embeddingVersion: "gemini-embedding-2-preview:768",
+          promptVersion: "enrich-v1",
+        },
+        false
+      )
+    ).toBe(false);
+  });
+
+  it("updates stale docs and force-updates current docs", () => {
+    expect(
+      shouldBackfillFamily(
+        family({ searchMeta: { embeddingModel: "old", embeddingVersion: "old:768", promptVersion: "enrich-v1" } }),
+        {
+          embeddingVersion: "gemini-embedding-2-preview:768",
+          promptVersion: "enrich-v1",
+        },
+        false
+      )
+    ).toBe(true);
+
+    expect(
+      shouldBackfillFamily(
+        family(),
+        {
+          embeddingVersion: "gemini-embedding-2-preview:768",
+          promptVersion: "enrich-v1",
+        },
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("parses owner, limit, force, and dry-run arguments", () => {
+    expect(parseBackfillArgs(["--ownerId=user-1", "--limit=25", "--force", "--dryRun"])).toEqual({
+      ownerId: "user-1",
+      limit: 25,
+      force: true,
+      dryRun: true,
+    });
+  });
+});

--- a/functions/tests/search/scoring.test.ts
+++ b/functions/tests/search/scoring.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { FontFamilyDoc } from "../../src/models/catalog.models";
+import {
+  DEFAULT_SEARCH_WEIGHTS,
+  exactMatchScore,
+  fuseCandidateScore,
+  mergeSearchCandidate,
+  semanticScoreFromDistance,
+} from "../../src/search/scoring";
+
+function family(id: string, overrides: Partial<FontFamilyDoc> = {}): FontFamilyDoc {
+  return {
+    id,
+    slug: id,
+    name: id === "garamond-premier" ? "Garamond Premier" : "Warm Sans",
+    fileBase: id,
+    category: id === "garamond-premier" ? "SERIF" : "SANS_SERIF",
+    faces: [],
+    status: "enriched",
+    version: 1,
+    searchTokens: id === "garamond-premier" ? ["garamond", "premier", "serif"] : ["warm", "sans", "branding"],
+    enrichment: {
+      category: id === "garamond-premier" ? "SERIF" : "SANS_SERIF",
+      moods: id === "garamond-premier" ? ["editorial"] : ["warm"],
+      useCases: id === "garamond-premier" ? ["books"] : ["branding"],
+      confidence: 0.9,
+    },
+    ...overrides,
+  };
+}
+
+describe("search scoring", () => {
+  it("normalizes Firestore cosine distance into a bounded semantic score", () => {
+    expect(semanticScoreFromDistance(0)).toBe(1);
+    expect(semanticScoreFromDistance(0.25)).toBe(0.75);
+    expect(semanticScoreFromDistance(2)).toBe(0);
+  });
+
+  it("scores exact name and token matches higher than loose token overlap", () => {
+    expect(exactMatchScore("Garamond Premier", family("garamond-premier"))).toBe(1);
+    expect(exactMatchScore("branding", family("warm-sans"))).toBeGreaterThan(0.5);
+    expect(exactMatchScore("cold brutalist", family("warm-sans"))).toBe(0);
+  });
+
+  it("deduplicates candidates by family id and preserves lane evidence", () => {
+    const candidates = new Map<string, ReturnType<typeof mergeSearchCandidate>>();
+    mergeSearchCandidate(candidates, family("warm-sans"), { lane: "text", score: 0.5 });
+    mergeSearchCandidate(candidates, family("warm-sans"), { lane: "mood", score: 0.9 });
+
+    const candidate = candidates.get("warm-sans");
+    expect(candidate?.scores.textSemantic).toBe(0.5);
+    expect(candidate?.scores.moodSemantic).toBe(0.9);
+    expect(candidates.size).toBe(1);
+  });
+
+  it("fuses weighted lanes deterministically and lets exact names beat weak semantic matches", () => {
+    const exact = fuseCandidateScore(
+      {
+        textSemantic: 0.1,
+        moodSemantic: 0,
+        useCaseSemantic: 0,
+        exact: 1,
+        quality: 0.8,
+      },
+      DEFAULT_SEARCH_WEIGHTS
+    );
+    const weakSemantic = fuseCandidateScore(
+      {
+        textSemantic: 0.18,
+        moodSemantic: 0.1,
+        useCaseSemantic: 0.1,
+        exact: 0,
+        quality: 0.8,
+      },
+      DEFAULT_SEARCH_WEIGHTS
+    );
+
+    expect(exact).toBeGreaterThan(weakSemantic);
+  });
+});

--- a/functions/tests/search/searchDocument.test.ts
+++ b/functions/tests/search/searchDocument.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { FontFamilyDoc } from "../../src/models/catalog.models";
+import {
+  buildLaneEmbeddingText,
+  buildQueryLaneInput,
+  buildSearchDocument,
+  tokenizeSearchText,
+} from "../../src/search/searchDocument";
+
+function family(overrides: Partial<FontFamilyDoc> = {}): FontFamilyDoc {
+  return {
+    id: "atlas-grotesk",
+    slug: "atlas-grotesk",
+    name: "Atlas Grotesk",
+    fileBase: "AtlasGrotesk",
+    category: "SANS_SERIF",
+    classification: "neo grotesque sans",
+    foundry: "Commercial Type",
+    faces: [
+      {
+        id: "regular",
+        styleName: "Regular",
+        weight: 400,
+        weightName: "Regular",
+        italic: false,
+        isVariable: false,
+        format: "OTF",
+        fileSize: 1200,
+        filename: "AtlasGrotesk-Regular.woff2",
+        woff2: { storagePath: "s/atlas/1/regular.woff2", url: "https://example.com/regular.woff2" },
+        original: { storagePath: "raw/atlas.otf", url: "https://example.com/raw.otf" },
+      },
+    ],
+    enrichment: {
+      category: "SANS_SERIF",
+      classification: "editorial grotesque",
+      summary: "A clear, warm grotesque for dense editorial systems.",
+      moods: ["warm", "precise", "editorial"],
+      voice: "quietly authoritative",
+      useCases: ["editorial headlines", "magazine decks", "brand systems"],
+      pairingHints: ["pairs with high contrast serif"],
+      confidence: 0.82,
+      promptVersion: "enrich-v1",
+      embeddingVersion: "gemini-embedding-2-preview:768",
+    },
+    status: "enriched",
+    version: 1,
+    ...overrides,
+  };
+}
+
+describe("search document utilities", () => {
+  it("normalizes and deduplicates searchable tokens across metadata and enrichment", () => {
+    expect(tokenizeSearchText(["Atlas Grotesk", "SANS_SERIF", "editorial headlines", "editorial"])).toEqual([
+      "atlas",
+      "grotesk",
+      "sans",
+      "serif",
+      "editorial",
+      "headlines",
+    ]);
+  });
+
+  it("builds lane-specific embedding inputs for broad text, mood, and use case retrieval", () => {
+    const doc = family();
+
+    expect(buildLaneEmbeddingText(doc, "text")).toContain("dense editorial systems");
+    expect(buildLaneEmbeddingText(doc, "mood")).toContain("warm");
+    expect(buildLaneEmbeddingText(doc, "mood")).toContain("quietly authoritative");
+    expect(buildLaneEmbeddingText(doc, "useCase")).toContain("magazine decks");
+    expect(buildLaneEmbeddingText(doc, "useCase")).toContain("pairs with high contrast serif");
+  });
+
+  it("builds clean lane query inputs without injecting document metadata", () => {
+    expect(buildQueryLaneInput("Warm geometric sans", "mood")).toBe("warm geometric sans");
+    expect(buildQueryLaneInput("Warm geometric sans", "useCase")).not.toContain("display");
+  });
+
+  it("builds persisted search fields and current search metadata", () => {
+    const update = buildSearchDocument(family(), {
+      embeddingModel: "gemini-embedding-2-preview",
+      embeddingVersion: "gemini-embedding-2-preview:768",
+      promptVersion: "enrich-v1",
+    });
+
+    expect(update.searchText).toContain("Atlas Grotesk");
+    expect(update.searchTokens).toContain("editorial");
+    expect(update.searchTokens).toContain("warm");
+    expect(update.searchMeta).toMatchObject({
+      embeddingModel: "gemini-embedding-2-preview",
+      embeddingVersion: "gemini-embedding-2-preview:768",
+      promptVersion: "enrich-v1",
+    });
+  });
+});

--- a/functions/tests/search/searchFonts.test.ts
+++ b/functions/tests/search/searchFonts.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FontFamilyDoc } from "../../src/models/catalog.models";
+
+type FakeDoc = {
+  id: string;
+  data: () => FontFamilyDoc;
+  get: (field: string) => unknown;
+};
+
+const queries: FakeQuery[] = [];
+let scenario = "useCase";
+
+function makeDoc(family: FontFamilyDoc, distance?: number): FakeDoc {
+  return {
+    id: family.id,
+    data: () => family,
+    get: (field: string) => (field === "_distance" ? distance : undefined),
+  };
+}
+
+function family(id: string, overrides: Partial<FontFamilyDoc> = {}): FontFamilyDoc {
+  return {
+    id,
+    slug: id,
+    name: id === "garamond-premier" ? "Garamond Premier" : id === "warm-sans" ? "Warm Sans" : "Editorial Grotesk",
+    fileBase: id,
+    category: id === "garamond-premier" ? "SERIF" : "SANS_SERIF",
+    faces: [],
+    ownerId: "owner-1",
+    status: "enriched",
+    version: 1,
+    searchTokens:
+      id === "garamond-premier"
+        ? ["garamond", "premier", "serif"]
+        : id === "warm-sans"
+          ? ["warm", "branding", "sans"]
+          : ["editorial", "magazine", "grotesk"],
+    enrichment: {
+      category: id === "garamond-premier" ? "SERIF" : "SANS_SERIF",
+      moods: id === "warm-sans" ? ["warm"] : ["precise"],
+      useCases: id === "editorial-grotesk" ? ["editorial"] : ["branding"],
+      confidence: 0.9,
+    },
+    ...overrides,
+  };
+}
+
+class FakeQuery {
+  readonly filters: Array<[string, string, unknown]>;
+  readonly limitValue?: number;
+  readonly vectorField?: string;
+
+  constructor(input: { filters?: Array<[string, string, unknown]>; limitValue?: number; vectorField?: string } = {}) {
+    this.filters = input.filters ?? [];
+    this.limitValue = input.limitValue;
+    this.vectorField = input.vectorField;
+    queries.push(this);
+  }
+
+  where(field: string, op: string, value: unknown): FakeQuery {
+    return new FakeQuery({ filters: [...this.filters, [field, op, value]], limitValue: this.limitValue, vectorField: this.vectorField });
+  }
+
+  limit(limitValue: number): FakeQuery {
+    return new FakeQuery({ filters: this.filters, limitValue, vectorField: this.vectorField });
+  }
+
+  findNearest(options: { vectorField: string }): FakeQuery {
+    return new FakeQuery({ filters: this.filters, limitValue: this.limitValue, vectorField: options.vectorField });
+  }
+
+  async get(): Promise<{ docs: FakeDoc[]; size: number }> {
+    const docs = docsForQuery(this);
+    return { docs, size: docs.length };
+  }
+}
+
+function docsForQuery(query: FakeQuery): FakeDoc[] {
+  if (!query.vectorField && query.filters.some(([field]) => field === "searchTokens")) {
+    if (scenario === "exactName") return [makeDoc(family("garamond-premier"))];
+    if (scenario === "useCase") return [makeDoc(family("editorial-grotesk"))];
+    return [makeDoc(family("warm-sans"))];
+  }
+
+  if (query.vectorField === "use_case_vec" && scenario === "useCase") {
+    return [makeDoc(family("editorial-grotesk"), 0.05)];
+  }
+  if (query.vectorField === "mood_vec" && scenario === "mood") {
+    return [makeDoc(family("warm-sans"), 0.02)];
+  }
+  if (query.vectorField === "text_vec" && scenario === "exactName") {
+    return [makeDoc(family("warm-sans"), 0.9)];
+  }
+  if (!query.vectorField && scenario === "fallback") {
+    return [makeDoc(family("editorial-grotesk")), makeDoc(family("warm-sans"))];
+  }
+  return [];
+}
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: () => new FakeQuery(),
+  }),
+}));
+
+vi.mock("firebase-functions", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/search/queryEmbeddingCache", () => ({
+  getOrCreateQueryEmbedding: vi.fn(async () => [0.1, 0.2, 0.3]),
+}));
+
+describe("searchFonts", () => {
+  beforeEach(() => {
+    queries.length = 0;
+    scenario = "useCase";
+  });
+
+  it("lets editorial queries rank through the use-case vector lane", async () => {
+    const { searchFonts } = await import("../../src/search/searchFonts");
+
+    const response = await searchFonts({ q: "editorial", filters: { ownerId: "owner-1" }, limit: 5, debug: true });
+
+    expect(response.results[0]?.id).toBe("editorial-grotesk");
+    expect(response.results[0]?.scoreBreakdown?.useCaseSemantic).toBeGreaterThan(0.9);
+  });
+
+  it("lets warm queries rank through the mood vector lane", async () => {
+    scenario = "mood";
+    const { searchFonts } = await import("../../src/search/searchFonts");
+
+    const response = await searchFonts({ q: "warm", filters: { ownerId: "owner-1" }, limit: 5, debug: true });
+
+    expect(response.results[0]?.id).toBe("warm-sans");
+    expect(response.results[0]?.scoreBreakdown?.moodSemantic).toBeGreaterThan(0.9);
+  });
+
+  it("lets an exact family name outrank weak semantic matches", async () => {
+    scenario = "exactName";
+    const { searchFonts } = await import("../../src/search/searchFonts");
+
+    const response = await searchFonts({ q: "Garamond Premier", filters: { ownerId: "owner-1" }, limit: 5, debug: true });
+
+    expect(response.results[0]?.id).toBe("garamond-premier");
+    expect(response.results[0]?.scoreBreakdown?.exact).toBe(1);
+  });
+
+  it("applies owner filtering to all Firestore lanes", async () => {
+    const { searchFonts } = await import("../../src/search/searchFonts");
+
+    await searchFonts({ q: "editorial", filters: { ownerId: "owner-1" }, limit: 5 });
+
+    const laneQueries = queries.filter((query) => query.vectorField || query.filters.some(([field]) => field === "searchTokens"));
+    expect(laneQueries.length).toBeGreaterThanOrEqual(4);
+    expect(laneQueries.every((query) => query.filters.some(([field, op, value]) => field === "ownerId" && op === "==" && value === "owner-1"))).toBe(true);
+  });
+
+  it("falls back to ready/enriched listing when the query is empty", async () => {
+    scenario = "fallback";
+    const { searchFonts } = await import("../../src/search/searchFonts");
+
+    const response = await searchFonts({ filters: { ownerId: "owner-1" }, limit: 5 });
+
+    expect(response.results.map((result) => result.id)).toEqual(["editorial-grotesk", "warm-sans"]);
+  });
+});


### PR DESCRIPTION
## Summary
Upgrades Seriph search from a single `text_vec` lane to hybrid retrieval over three semantic vectors (`text_vec`, `mood_vec`, `use_case_vec`) plus an exact/token lane, merged by family id with deterministic score fusion.

## Changes
- **Search engine** (`searchFonts.ts`): three vector lanes run in parallel after per-lane query embedding, plus an exact/token lane; merge by family id; rerank with weighted fusion (text 0.45, mood 0.20, useCase 0.20, exact 0.10, quality 0.05). `scoreBreakdown` exposed only under a debug flag. Per-stage timing logs.
- **Lane abstractions** (`searchDocument.ts`, `scoring.ts`): normalization, tokenization, lane input/embedding text, semantic/exact/quality scoring, candidate merge + fusion.
- **Query cache** (`queryEmbeddingCache.ts`): 7-day Firestore `searchQueryCache`, keyed by normalized query + embedding model/version + lane.
- **Enrichment** (`enrich/update.ts`, `enrich/schema.ts`): writes all three embeddings + `searchText`/`searchTokens`/`searchMeta` on enrichment.
- **Backfill** (`scripts/backfillSearchVectors.ts`): recomputes search fields for existing families; `--force` / `--ownerId` / `--limit` / `--dryRun`; skips docs already at current version.
- **Indexes** (`firestore.indexes.json`): owner-scoped vector + token indexes for all three lanes (dim 2048).
- **Schema** (`catalog.models.ts`): `searchText`, `searchTokens`, `searchMeta`, vector fields; `image_vec` reserved for a future lane.

Image vectors intentionally deferred. Search stays submit-based.

## Verification
All gates green locally: functions build/typecheck/tests (47), web typecheck/lint (0 warnings)/tests (6)/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)