### PR TITLE
Make family browsing instant: cache + viewport-gated font loading

### DIFF
--- a/components/font/FamilyCover.tsx
+++ b/components/font/FamilyCover.tsx
@@ -3,6 +3,7 @@
 import { FontFamily } from '@/models/font.models';
 import Link from 'next/link';
 import { useRegisterFamilyFonts } from '@/lib/hooks/useRegisterFamilyFonts';
+import { useInViewport } from '@/lib/hooks/useInViewport';
 
 interface FamilyCoverProps {
   family: FontFamily;
@@ -36,14 +37,17 @@ function getSampleChars(classification: string): string {
 }
 
 export default function FamilyCover({ family, mode, coverSeed = 0 }: FamilyCoverProps) {
-  // Ensure fonts are registered so samples render with the actual family
-  useRegisterFamilyFonts(family);
+  // Only register (download) the family's fonts once the card nears the viewport,
+  // so a shelf of hundreds of families doesn't load every font up front.
+  const { ref, inView } = useInViewport<HTMLAnchorElement>('500px');
+  useRegisterFamilyFonts(family, { enabled: inView, representativeOnly: true });
   const pattern = getFamilyPattern(family.name, coverSeed);
   const sampleChars = getSampleChars(family.classification);
   const isVariable = family.fonts?.some((f) => f.isVariable);
 
   return (
     <Link
+      ref={ref}
       href={`/family/${family.id}`}
       className="relative h-full rule rounded-[var(--radius)] overflow-hidden flex flex-col cursor-pointer transition-transform hover:scale-[1.02]"
       style={{ background: pattern }}

--- a/components/home/ShelfState.tsx
+++ b/components/home/ShelfState.tsx
@@ -17,9 +17,15 @@ interface ShelfStateProps {
   coverSeed?: number;
 }
 
+// Above this many families, per-item layout animations (FLIP tracking on every
+// card) cost more than they're worth — render plain cards so big shelves stay
+// responsive while small libraries keep the springy entrance.
+const LAYOUT_ANIMATION_LIMIT = 60;
+
 export default function ShelfState({ families, pendingIngests, shelfMode, onAddFonts, coverSeed = 0 }: ShelfStateProps) {
   const activeUploads = pendingIngests.filter((ingest) => ingest.status !== 'completed');
   const shouldReduceMotion = useReducedMotion() ?? false;
+  const animateCards = !shouldReduceMotion && families.length <= LAYOUT_ANIMATION_LIMIT;
 
   // Announce status changes for accessibility.
   useEffect(() => {
@@ -39,22 +45,30 @@ export default function ShelfState({ families, pendingIngests, shelfMode, onAddF
         ))}
       </AnimatePresence>
 
-      <AnimatePresence mode="popLayout">
-        {families.map((family) => (
-          <motion.div
-            key={family.id}
-            layout={!shouldReduceMotion}
-            layoutId={shouldReduceMotion ? undefined : `family-${family.id}`}
-            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.9 }}
-            animate={shouldReduceMotion ? {} : { opacity: 1, scale: 1 }}
-            exit={shouldReduceMotion ? undefined : { opacity: 0, scale: 0.9 }}
-            transition={shouldReduceMotion ? {} : { type: 'spring', damping: 25, stiffness: 300 }}
-            className="h-full"
-          >
+      {animateCards ? (
+        <AnimatePresence mode="popLayout">
+          {families.map((family) => (
+            <motion.div
+              key={family.id}
+              layout
+              layoutId={`family-${family.id}`}
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+              className="h-full"
+            >
+              <FamilyCover family={family} mode={shelfMode} coverSeed={coverSeed} />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      ) : (
+        families.map((family) => (
+          <div key={family.id} className="h-full">
             <FamilyCover family={family} mode={shelfMode} coverSeed={coverSeed} />
-          </motion.div>
-        ))}
-      </AnimatePresence>
+          </div>
+        ))
+      )}
 
       <div
         className="relative rule p-4 sm:p-5 md:p-6 rounded-[var(--radius)] flex flex-col justify-between group cursor-pointer"

--- a/lib/cache/familyCache.ts
+++ b/lib/cache/familyCache.ts
@@ -1,0 +1,21 @@
+import type { FontFamily } from '@/models/font.models';
+
+/**
+ * Process-wide in-memory cache of fully-adapted families, keyed by id. The shelf
+ * loads every family into memory anyway, so family-detail navigation can be
+ * served instantly from here instead of refetching by id on each visit. Survives
+ * client-side route changes (module singleton); cleared on full reload.
+ */
+const familiesById = new Map<string, FontFamily>();
+
+export function cacheFamilies(families: FontFamily[]): void {
+  for (const family of families) familiesById.set(family.id, family);
+}
+
+export function cacheFamily(family: FontFamily): void {
+  familiesById.set(family.id, family);
+}
+
+export function getCachedFamily(id: string | undefined): FontFamily | undefined {
+  return id ? familiesById.get(id) : undefined;
+}

--- a/lib/firebase/config.ts
+++ b/lib/firebase/config.ts
@@ -1,5 +1,11 @@
 import { initializeApp, getApps, getApp, FirebaseApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import {
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  getFirestore,
+  type Firestore,
+} from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 
 // Firebase project configuration using environment variables
@@ -31,7 +37,22 @@ if (!getApps().length) {
   app = getApp();
 }
 
-const db = getFirestore(app);
+// Firestore with an IndexedDB-backed offline cache in the browser: repeat reads
+// (the family list, family-detail revisits) serve instantly from local cache and
+// dedupe network fetches. Falls back to the default in-memory cache on the server
+// or when persistence is unavailable (e.g. private-mode / HMR re-init).
+function createDb(): Firestore {
+  if (typeof window === "undefined") return getFirestore(app);
+  try {
+    return initializeFirestore(app, {
+      localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }),
+    });
+  } catch {
+    return getFirestore(app);
+  }
+}
+
+const db = createDb();
 const storage = getStorage(app);
 
 export { app, db, storage };

--- a/lib/hooks/useFamilies.ts
+++ b/lib/hooks/useFamilies.ts
@@ -5,6 +5,7 @@ import { Timestamp } from 'firebase/firestore';
 import type { User } from 'firebase/auth';
 import type { FontFamily } from '@/models/font.models';
 import { getAllFontFamilies } from '@/lib/db/firestoreUtils';
+import { cacheFamilies } from '@/lib/cache/familyCache';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { useUploads } from '@/lib/contexts/UploadContext';
 
@@ -31,7 +32,9 @@ async function loadFamiliesForUser(user: User): Promise<FontFamily[]> {
   if (cached) {
     const { timestamp, data } = JSON.parse(cached);
     if (Date.now() - timestamp < CACHE_TTL_MS && data.length > 0) {
-      return serialize(data);
+      const families = serialize(data);
+      cacheFamilies(families);
+      return families;
     }
   }
 
@@ -47,7 +50,17 @@ async function loadFamiliesForUser(user: User): Promise<FontFamily[]> {
     throw new Error(errorMessage || 'Failed to load font families.');
   }
 
-  if (result.length > 0) localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data: result }));
+  if (result.length > 0) {
+    cacheFamilies(result);
+    // Best-effort persistence: the full catalog can exceed the localStorage quota
+    // at scale, so never let a write failure break loading (Firestore's IndexedDB
+    // cache is the durable cross-reload layer).
+    try {
+      localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data: result }));
+    } catch {
+      /* quota exceeded — rely on the Firestore offline cache instead */
+    }
+  }
   return result;
 }
 

--- a/lib/hooks/useFamilyDetail.ts
+++ b/lib/hooks/useFamilyDetail.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Timestamp } from 'firebase/firestore';
 import type { FontFamily } from '@/models/font.models';
 import { getFontFamilyById } from '@/lib/db/firestoreUtils';
+import { cacheFamily, getCachedFamily } from '@/lib/cache/familyCache';
 import { useAuth } from '@/lib/contexts/AuthContext';
 
 function serialize(family: any): FontFamily | null {
@@ -26,22 +27,30 @@ export function useFamilyDetail(familyId: string | undefined) {
     error: string | null;
   }>({ familyId: null, family: null, error: null });
   const activeFamilyId = familyId ?? null;
+  // The shelf loads every family into the shared cache, so in-app navigation can
+  // render the detail instantly without a refetch (back/forward feels immediate).
+  const cached = user ? getCachedFamily(activeFamilyId ?? undefined) : undefined;
   const routeError = !authLoading && user && !activeFamilyId ? 'Font family ID is not available in the route.' : null;
   const hasCurrentFamilyState = state.familyId === activeFamilyId;
-  const family = user && hasCurrentFamilyState ? state.family : null;
+  const family = user ? (hasCurrentFamilyState ? state.family : cached ?? null) : null;
   const error = user ? routeError ?? (hasCurrentFamilyState ? state.error : null) : null;
-  const isLoading = authLoading || Boolean(user && activeFamilyId && !hasCurrentFamilyState);
+  const isLoading = authLoading || Boolean(user && activeFamilyId && !hasCurrentFamilyState && !cached);
 
   useEffect(() => {
     if (authLoading || !user || !familyId) return;
+
+    // Already in the shared cache → the derived value renders it; skip the fetch.
+    if (getCachedFamily(familyId)) return;
 
     let isActive = true;
     getFontFamilyById(familyId)
       .then((raw) => {
         if (!isActive) return;
+        const serialized = raw ? serialize(raw) : null;
+        if (serialized) cacheFamily(serialized);
         setState({
           familyId,
-          family: raw ? serialize(raw) : null,
+          family: serialized,
           error: raw ? null : 'Font family not found. It might have been moved or deleted.',
         });
       })

--- a/lib/hooks/useInViewport.ts
+++ b/lib/hooks/useInViewport.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Tracks whether the referenced element is in (or near) the viewport. Used to
+ * defer expensive per-card work — like downloading a family's font files — until
+ * the card actually scrolls into view, so a shelf of hundreds of families does
+ * not load hundreds of fonts at once.
+ */
+export function useInViewport<T extends Element>(
+  rootMargin = '0px'
+): { ref: React.RefObject<T | null>; inView: boolean } {
+  const ref = useRef<T | null>(null);
+  // Without IntersectionObserver (SSR / very old browsers) treat everything as
+  // visible so content still loads; otherwise start hidden until observed.
+  const [inView, setInView] = useState<boolean>(() => typeof IntersectionObserver === 'undefined');
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) setInView(entry.isIntersecting);
+      },
+      { rootMargin }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return { ref, inView };
+}

--- a/lib/hooks/useRegisterFamilyFonts.ts
+++ b/lib/hooks/useRegisterFamilyFonts.ts
@@ -45,7 +45,33 @@ function buildFontFaceRule(
   }`;
 }
 
-export function useRegisterFamilyFonts(family: FontFamily | null | undefined) {
+/**
+ * Injects `@font-face` rules for a family's faces into the document head.
+ *
+ * `enabled` lets callers defer the work until a card is actually on screen, so a
+ * shelf of hundreds of families doesn't download every font at once. The rules
+ * are removed when disabled or unmounted, keeping the head and the set of active
+ * font downloads bounded as the user scrolls or navigates (the browser HTTP
+ * cache makes re-registration cheap on the way back).
+ *
+ * `representativeOnly` registers a single face (a variable face if present, else
+ * the boldest static one) — enough for a cover's display sample, so a shelf card
+ * pulls one font file instead of the whole family.
+ */
+function pickRepresentativeFace(fonts: FontVariant[]): FontVariant[] {
+  if (fonts.length <= 1) return fonts;
+  const variable = fonts.find((f) => f.isVariable);
+  if (variable) return [variable];
+  const boldest = fonts.reduce((a, b) => ((b.weight || 0) > (a.weight || 0) ? b : a));
+  return [boldest];
+}
+
+export function useRegisterFamilyFonts(
+  family: FontFamily | null | undefined,
+  options?: { enabled?: boolean; representativeOnly?: boolean }
+) {
+  const enabled = options?.enabled ?? true;
+  const representativeOnly = options?.representativeOnly ?? false;
   const styleId = family ? `seriph-fonts-${family.id}` : null;
   const fontFaceRules = useMemo(() => {
     if (!family || !family.fonts || family.fonts.length === 0) return '';
@@ -53,7 +79,8 @@ export function useRegisterFamilyFonts(family: FontFamily | null | undefined) {
     // Build rules for each variant, proxying URLs through our API to avoid CORS
     const rules: string[] = [];
     const seen = new Set<string>();
-    for (const v of family.fonts) {
+    const faces = representativeOnly ? pickRepresentativeFace(family.fonts) : family.fonts;
+    for (const v of faces) {
       // Prefer the stable CDN url (woff2); fall back to the legacy proxy.
       const cdn = (v?.metadata as any)?.cdnUrl as string | undefined;
       const storagePath = v?.metadata?.storagePath || null;
@@ -66,10 +93,10 @@ export function useRegisterFamilyFonts(family: FontFamily | null | undefined) {
     }
 
     return rules.join('\n\n');
-  }, [family]);
+  }, [family, representativeOnly]);
 
   useEffect(() => {
-    if (!styleId || !fontFaceRules) return;
+    if (!styleId || !fontFaceRules || !enabled) return;
 
     let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
     if (!styleEl) {
@@ -77,9 +104,12 @@ export function useRegisterFamilyFonts(family: FontFamily | null | undefined) {
       styleEl.id = styleId;
       document.head.appendChild(styleEl);
     }
-
     styleEl.innerHTML = fontFaceRules;
 
-    // No cleanup to persist loaded fonts; updating is handled by replacing innerHTML
-  }, [styleId, fontFaceRules]);
+    // Drop the rules when this card scrolls away / unmounts so the active set of
+    // font downloads stays bounded. Re-registering on return is cheap (HTTP cache).
+    return () => {
+      document.getElementById(styleId)?.remove();
+    };
+  }, [styleId, fontFaceRules, enabled]);
 }


### PR DESCRIPTION
## Problem
The home shelf rendered one cover per family, and every cover injected `@font-face` rules for **all** faces of its family with **no cleanup** — so a library of hundreds of families downloaded hundreds-to-thousands of woff2 files just to show 2-char samples, and the cost grew with every family. Detail views refetched by id on each visit, and there was no offline cache.

## Fixes
- `useRegisterFamilyFonts(family, { enabled, representativeOnly })`: defer registration until on screen + clean up `<style>` on disable/unmount; covers register one representative face (variable, else boldest) instead of the whole family.
- `useInViewport`: IntersectionObserver hook; `FamilyCover` loads its font only when the card nears the viewport.
- `lib/firebase/config.ts`: IndexedDB `persistentLocalCache` (browser) so repeat reads serve instantly and dedupe network fetches; memory cache on server.
- `lib/cache/familyCache.ts`: shared in-memory family map; `useFamilies` populates it so `useFamilyDetail` renders in-app navigation instantly with no refetch.
- `useFamilies`: quota-safe localStorage write.
- `ShelfState`: drop per-item FLIP layout animation above 60 families.

## Verification
Local: typecheck, lint (0 warnings), tests, build all green. Vercel preview built green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)